### PR TITLE
Fixes invalid sqlite3 line separator

### DIFF
--- a/esqlite.el
+++ b/esqlite.el
@@ -560,6 +560,7 @@ Cygwin: FILE name contains multibyte char, may fail to open FILE as database."
                  "-interactive"
                  "-init" ,init
                  "-csv"
+                 "-newline" "\n"
                  "-nullvalue" ,null
                  ;; prior than preceeding args
                  ,@args

--- a/esqlite.el
+++ b/esqlite.el
@@ -593,6 +593,7 @@ Cygwin: FILE contains multibyte char, may fail to open FILE as database."
                  "-batch"
                  "-init" ,init
                  "-csv"
+                 "-newline" "\n"
                  "-nullvalue" ,null
                  ;; prior than preceeding args
                  ,@args


### PR DESCRIPTION
esqlte does not work with the new version of `sqlite3` 3.52.0.. `sqlite3`  returns results with the `"\r\n"` line separator. Although the documentation indicates that the default line separator should be `"\n"`, `sqlite3` uses `"\r\n"` instead. `-newline `option with `\n` fixes the issue #7.